### PR TITLE
Add support for recurring meetings

### DIFF
--- a/app/controllers/office_hours_controller.rb
+++ b/app/controllers/office_hours_controller.rb
@@ -3,6 +3,7 @@
 
 class OfficeHoursController < ApplicationController
   WEEKDAYS = [%w[S sunday], %w[M monday], %w[T tuesday], %w[W wednesday], %w[T thursday], %w[F friday], %w[S saturday]]
+  INT_DAYS = {sunday: 7, monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6}
 
   def index
 
@@ -62,7 +63,7 @@ class OfficeHoursController < ApplicationController
     if @recurrences
       @recurrences.each do |day, active|
         if active == "1"
-          @oh.office_hour_recurrence.create(day_of_week: day)
+          @oh.office_hour_recurrence.create(day_of_week: INT_DAYS[day.to_sym])
         end
       end
     end

--- a/app/models/office_hour.rb
+++ b/app/models/office_hour.rb
@@ -3,11 +3,13 @@ class OfficeHour < ActiveRecord::Base
   validates :class_name, presence: true, allow_blank: false
   # We don't actually need to ensure it's a valid date since the form
   # date picker only submits valid dates.
-  validates :time, presence: true, allow_blank: false
+	validates :starts_on, presence: true, allow_blank: false
+	validates :ends_on, presence: true, allow_blank: false
   validates :zoom_info, presence: true, allow_blank: false
 
   belongs_to :user
   has_many :queue_entries, -> {order("start_time asc")}
+	has_many :office_hour_recurrence, dependent: :destroy
 
   def self.with_search(search, order)
   	if order.nil?

--- a/app/models/office_hour.rb
+++ b/app/models/office_hour.rb
@@ -3,25 +3,50 @@ class OfficeHour < ActiveRecord::Base
   validates :class_name, presence: true, allow_blank: false
   # We don't actually need to ensure it's a valid date since the form
   # date picker only submits valid dates.
-	validates :starts_on, presence: true, allow_blank: false
-	validates :ends_on, presence: true, allow_blank: false
+  validates :starts_on, presence: true, allow_blank: false
+  validates :ends_on, presence: true, allow_blank: false
   validates :zoom_info, presence: true, allow_blank: false
 
   belongs_to :user
-  has_many :queue_entries, -> {order("start_time asc")}
-	has_many :office_hour_recurrence, dependent: :destroy
+  has_many :queue_entries, -> { order("start_time asc") }
+  has_many :office_hour_recurrence, dependent: :destroy
 
   def self.with_search(search, order)
-  	if order.nil?
-  	 oh = OfficeHour.all
-  	else
-  	 oh = OfficeHour.order(order)
-  	end
+    if order.nil?
+      oh = OfficeHour.all
+    else
+      oh = OfficeHour.order(order)
+    end
 
-  	if search.nil?
-  		return oh
-  	end
-  	
-  	return oh.where('host LIKE :search OR class_name LIKE :search', search: "%#{search[:search]}%")
+    if search
+      oh = oh.where('host LIKE :search OR class_name LIKE :search', search: "%#{search[:search]}%")
+    end
+    rehydrated = []
+    oh.each do |event|
+      if event.office_hour_recurrence.count > 0 and event.repeats_until
+        # Maybe this can be simpler
+        weekdays = event.office_hour_recurrence.select(:day_of_week)
+        repeats_on = []
+        weekdays.each do |wd|
+          repeats_on.push wd.day_of_week
+        end
+        puts repeats_on
+        curr = event.starts_on.clone
+        while curr < event.repeats_until + 1.day
+          if repeats_on.include? curr.wday
+            # Not sure if this is too hacky, but since we never save these to the database it should be fine
+            o = OfficeHour.new id: event.id, starts_on: curr, host: event.host, class_name: event.class_name, zoom_info: event.zoom_info
+            rehydrated.push o
+          end
+          curr = curr + 1.day
+        end
+      else
+        rehydrated.push(event)
+      end
+    end
+    if order.eql? "starts_on" or order.nil?
+      rehydrated = rehydrated.sort_by {|item| item.starts_on}
+    end
+    return rehydrated
   end
 end

--- a/app/models/office_hour.rb
+++ b/app/models/office_hour.rb
@@ -30,7 +30,6 @@ class OfficeHour < ActiveRecord::Base
         weekdays.each do |wd|
           repeats_on.push wd.day_of_week
         end
-        puts repeats_on
         curr = event.starts_on.clone
         while curr < event.repeats_until + 1.day
           if repeats_on.include? curr.wday

--- a/app/models/office_hour_recurrence.rb
+++ b/app/models/office_hour_recurrence.rb
@@ -1,5 +1,5 @@
 class OfficeHourRecurrence < ApplicationRecord
   belongs_to :office_hour
-  validates :day_of_week, inclusion: { in: %w(sunday monday tuesday wednesday thursday friday saturday),
-                                       message: "%{value} is not a valid day of the week" }
+  # validates :day_of_week, inclusion: { in: %w(sunday monday tuesday wednesday thursday friday saturday),
+  #                                      message: "%{value} is not a valid day of the week" }
 end

--- a/app/models/office_hour_recurrence.rb
+++ b/app/models/office_hour_recurrence.rb
@@ -1,0 +1,5 @@
+class OfficeHourRecurrence < ApplicationRecord
+  belongs_to :office_hour
+  validates :day_of_week, inclusion: { in: %w(sunday monday tuesday wednesday thursday friday saturday),
+                                       message: "%{value} is not a valid day of the week" }
+end

--- a/app/views/office_hours/index.html.erb
+++ b/app/views/office_hours/index.html.erb
@@ -5,11 +5,11 @@
     <tr>
       <th class='<%= @tclass%>'><%= link_to "Host", office_hours_path(request.parameters.merge({:asc => :host})), class: @tclass, id: "host_header" %></th>
       <th class='<%= @rdclass%>'><%= link_to "Class Name", office_hours_path(request.parameters.merge({:asc => :class_name})), class: @rdclass, id: "class_name_header" %></th>
-      <th class='<%= @fugclass%>'><%= link_to "When", office_hours_path(request.parameters.merge({:asc => :time})), class: @fugclass, id: "time_header" %></th>
+      <th class='<%= @fugclass%>'><%= link_to "When", office_hours_path(request.parameters.merge({:asc => :starts_on})), class: @fugclass, id: "time_header" %></th>
       <th>More Info</th>
     </tr>
   </thead>
-  <div class="row">
+  <div class="row" style="padding-bottom: 15px">
     <div class="" style="background-color: #d6d8db;padding: .25em; border-radius: 5px; width: 100%">
     <%= form_tag office_hours_path, method: :get, id: 'search_form' do %>
       Search for TA or OH:
@@ -24,7 +24,7 @@
       <tr>
         <td><%= oh.host %></td>
         <td><%= oh.class_name %></td>
-        <td><%= oh.time.strftime("%m/%d/%Y %I:%M%p") %></td>
+        <td><%= oh.starts_on.strftime("%m/%d/%Y %I:%M%p") %></td>
         <td>
           <%= link_to "See more", office_hour_path(oh) %>
         </td>

--- a/app/views/office_hours/new.html.erb
+++ b/app/views/office_hours/new.html.erb
@@ -2,16 +2,57 @@
 
 <%= form_tag office_hours_path, :class => 'form' do %>
   <%# TODO(etm): Host name field should be automatic based on the user that's logged in %>
-  <%= text_field :office_hour, :host, placeholder: "Host name", :class => 'col-form-control',
-                 :value => @oh.host, :required => true %>
-  <%= text_field :office_hour, :class_name, placeholder: "Class name", :class => 'col-form-control',
-                 :value => @oh.class_name, :required => true %>
-  <%= datetime_local_field :office_hour, :time, :class => 'col-form-control',
-    :value => if @oh.time then @oh.time.strftime('%Y-%m-%dT%H:%M') end, :required => true, :placeholder => "YYYY-MM-DD HH:MM PM/AM" %>
-  <%= text_field :office_hour, :zoom_info, placeholder: "Zoom link", :class => 'col-form-control',
-                 :value => @oh.zoom_info, :required => true %>
+  <div class="form-row">
+    <div class="form-group col-md-6">
+      <%= label_tag :host, "Host name" %>
+      <%= text_field :office_hour, :host, placeholder: "Host name", :class => 'form-control',
+                     :value => @oh.host, :required => true %>
+    </div>
+    <div class="form-group col-md-6">
+      <%= label_tag :host, "Class name" %>
+      <%= text_field :office_hour, :class_name, placeholder: "Class name", :class => 'form-control',
+                     :value => @oh.class_name, :required => true %>
+    </div>
+  </div>
+  <div class="form-row">
+    <div class="form-group col-md-6">
+      <%= label_tag :start_date, "Starts On" %>
+      <%= datetime_local_field :office_hour, :starts_on, :class => 'form-control',
+                               :value => if @oh.starts_on then
+                                           @oh.starts_on.strftime('%Y-%m-%dT%H:%M')
+                                         end, :required => true, :placeholder => "YYYY-MM-DD HH:MM PM/AM" %>
+    </div>
+    <div class="form-group col-md-6">
+      <%= label_tag :start_date, "Ends On" %>
+      <%= datetime_local_field :office_hour, :ends_on, :class => 'form-control',
+                               :value => if @oh.ends_on then
+                                           @oh.ends_on.strftime('%Y-%m-%dT%H:%M')
+                                         end, :required => true, :placeholder => "YYYY-MM-DD HH:MM PM/AM" %>
+    </div>
+  </div>
+  <div class="form-group">
+    <%= label_tag :zoom_info, "Zoom Link" %>
+    <%= text_field :office_hour, :zoom_info, placeholder: "Zoom link", :class => 'form-control',
+                   :value => @oh.zoom_info, :required => true %>
+  </div>
   <%= hidden_field :office_hour, :active, value: false %>
-  <br/>
-  <%= submit_tag 'Save Changes', :class => 'btn btn-primary' %>
-  <%= link_to 'Cancel', office_hours_path, :class => 'btn btn-secondary' %>
+  <div class="form-row">
+    <div class="form-group col-md-6">
+      <%= label_tag :repeats_until, "Repeats Until" %>
+      <%= date_field :office_hour, :repeats_until, :class => 'form-control' %>
+    </div>
+    <div class="form-group col-md-6">
+      <div style="margin-bottom: .5rem">Repeats Weekly On</div>
+      <% @weekdays.each do |short_label, weekday| %>
+        <div class="form-check form-check-inline">
+          <%= check_box_tag "recurrences[#{weekday}", 1, @recurrences.include?(weekday), :class => 'form-check-input' %>
+          <%= label_tag "recurrences[#{weekday}", short_label, :class => 'form-check-label' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  <div style="margin-top: 15px">
+    <%= submit_tag 'Save Changes', :class => 'btn btn-primary' %>
+    <%= link_to 'Cancel', office_hours_path, :class => 'btn btn-secondary' %>
+  </div>
 <% end %>

--- a/app/views/office_hours/show.html.erb
+++ b/app/views/office_hours/show.html.erb
@@ -13,7 +13,7 @@
       <%# <li class="list-group-item list-group-item-secondary">Details</li> %>
         <li class="list-group-item">
           Date/time:
-          <%= @oh.time.strftime("%m/%d/%Y %I:%M%p") %>
+          <%= @oh.starts_on.strftime("%m/%d/%Y %I:%M%p") %>
         </li>
         <li class="list-group-item">
           Zoom info: <a href=<%= @oh.zoom_info %>>link</a>

--- a/db/migrate/20210329201133_recurring_events.rb
+++ b/db/migrate/20210329201133_recurring_events.rb
@@ -1,0 +1,13 @@
+class RecurringEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :office_hours, :starts_on, :datetime
+    add_column :office_hours, :ends_on, :datetime
+    add_column :office_hours, :repeats_until, :date
+    remove_column :office_hours, :time
+
+    create_table "office_hour_recurrences", force: :cascade do |t|
+      t.string "day_of_week" # TODO: This should be an enum
+    end
+    add_reference :office_hour_recurrences, :office_hour, index: true, foreign_key: true, null: false
+  end
+end

--- a/db/migrate/20210329201133_recurring_events.rb
+++ b/db/migrate/20210329201133_recurring_events.rb
@@ -6,7 +6,8 @@ class RecurringEvents < ActiveRecord::Migration[6.1]
     remove_column :office_hours, :time
 
     create_table "office_hour_recurrences", force: :cascade do |t|
-      t.string "day_of_week" # TODO: This should be an enum
+      t.integer "day_of_week", null: false # TODO: This should be an enum
+      t.check_constraint "day_of_week >= 1 AND day_of_week <= 7"
     end
     add_reference :office_hour_recurrences, :office_hour, index: true, foreign_key: true, null: false
     add_index :office_hour_recurrences, [:id, :day_of_week], :unique => true

--- a/db/migrate/20210329201133_recurring_events.rb
+++ b/db/migrate/20210329201133_recurring_events.rb
@@ -9,5 +9,6 @@ class RecurringEvents < ActiveRecord::Migration[6.1]
       t.string "day_of_week" # TODO: This should be an enum
     end
     add_reference :office_hour_recurrences, :office_hour, index: true, foreign_key: true, null: false
+    add_index :office_hour_recurrences, [:id, :day_of_week], :unique => true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_25_232412) do
+ActiveRecord::Schema.define(version: 2021_03_29_201133) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,15 +52,23 @@ ActiveRecord::Schema.define(version: 2021_03_25_232412) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "office_hour_recurrences", force: :cascade do |t|
+    t.string "day_of_week"
+    t.bigint "office_hour_id", null: false
+    t.index ["office_hour_id"], name: "index_office_hour_recurrences_on_office_hour_id"
+  end
+
   create_table "office_hours", id: :serial, force: :cascade do |t|
-    t.string "host"
-    t.string "class_name"
-    t.datetime "time"
-    t.string "zoom_info"
+    t.text "host"
+    t.text "class_name"
+    t.text "zoom_info"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
     t.boolean "active", default: false
+    t.bigint "user_id", null: false
+    t.datetime "starts_on"
+    t.datetime "ends_on"
+    t.date "repeats_until"
     t.index ["user_id"], name: "index_office_hours_on_user_id"
   end
 
@@ -93,6 +101,7 @@ ActiveRecord::Schema.define(version: 2021_03_25_232412) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "office_hour_recurrences", "office_hours"
   add_foreign_key "office_hours", "users"
   add_foreign_key "queue_entries", "office_hours"
   add_foreign_key "queue_entries", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,10 +53,11 @@ ActiveRecord::Schema.define(version: 2021_03_29_201133) do
   end
 
   create_table "office_hour_recurrences", force: :cascade do |t|
-    t.string "day_of_week"
+    t.integer "day_of_week", null: false
     t.bigint "office_hour_id", null: false
     t.index ["id", "day_of_week"], name: "index_office_hour_recurrences_on_id_and_day_of_week", unique: true
     t.index ["office_hour_id"], name: "index_office_hour_recurrences_on_office_hour_id"
+    t.check_constraint "(day_of_week >= 1) AND (day_of_week <= 7)"
   end
 
   create_table "office_hours", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2021_03_29_201133) do
   create_table "office_hour_recurrences", force: :cascade do |t|
     t.string "day_of_week"
     t.bigint "office_hour_id", null: false
+    t.index ["id", "day_of_week"], name: "index_office_hour_recurrences_on_id_and_day_of_week", unique: true
     t.index ["office_hour_id"], name: "index_office_hour_recurrences_on_office_hour_id"
   end
 

--- a/features/chat.feature
+++ b/features/chat.feature
@@ -6,19 +6,19 @@ Feature: Chat while you're waiting the queue
 
   Background: office hour exists
     Given the following user exists:
-      | id | email               | password    |
-      | 1  | ta6969@columbia.edu | memexD |
+      | id | email               | password |
+      | 1  | ta6969@columbia.edu | memexD   |
 
     Given the following office hour exists:
-      | id | host   | class_name               | time   | zoom_info    | user_id |
-      | 1  | TA-kun | Underwater Basketwelding | 5:00PM | http://zo.om | 1       |
+      | id | host   | class_name               | starts_on | ends_on | zoom_info    | user_id |
+      | 1  | TA-kun | Underwater Basketwelding | 5:00PM   | 6:00PM  | http://zo.om | 1       |
 
     Given the following queue entry exists:
-      | id   | student     | description  | creator_id | office_hour_id |
-      | 100  | Evan-senpai | Please help! | 12345      | 1              |
+      | id  | student     | description  | creator_id | office_hour_id |
+      | 100 | Evan-senpai | Please help! | 12345      | 1              |
 
     Given the following chats exist:
-      | id  | name | msg                 | office_hour_id | queue_entry_id | 
+      | id  | name | msg                 | office_hour_id | queue_entry_id |
       | 100 | Hans | Did you try Google? | 1              | 100            |
 
   @javascript
@@ -32,14 +32,14 @@ Feature: Chat while you're waiting the queue
     Then I should see "Did you try Google?"
 
   @javascript
-   Scenario: User contributes to an ongoing chat
-     Given it is currently "5:05 pm"
-     And office hour 1 is active
-     When I go to the home page
-     And I follow "See more"
-     Then I should see "Evan-senpai"
-     When I press "Thread (+1)"
-     Then I should see "Did you try Google?"
-     When I send a message with name "Matt" and message "that didn't help" 
-     Then I should see "that didn't help"
-     And I should see "Thread (+2)"
+  Scenario: User contributes to an ongoing chat
+    Given it is currently "5:05 pm"
+    And office hour 1 is active
+    When I go to the home page
+    And I follow "See more"
+    Then I should see "Evan-senpai"
+    When I press "Thread (+1)"
+    Then I should see "Did you try Google?"
+    When I send a message with name "Matt" and message "that didn't help"
+    Then I should see "that didn't help"
+    And I should see "Thread (+2)"

--- a/features/create_oh.feature
+++ b/features/create_oh.feature
@@ -26,3 +26,29 @@ Scenario: create an office hours
   Then I should be on the home page
   And I should see "Underwater Basketweaving" 
   And I should see "TA-kun"
+
+  Scenario: create a rcurring office hours
+    When I go to the OH create page
+    Then I should be on the log in page
+    When I fill in "Email" with "ta6969@colombia.edu"
+    When I fill in "Password" with "memexD"
+    And I press "Log in"
+
+
+    Then I should be on the OH create page
+    When I fill in "office_hour_host" with "TA-kun"
+    And I fill in "office_hour_class_name" with "Underwater Basketweaving"
+    And I fill in "office_hour_starts_on" with "2021-03-01"
+    And I fill in "office_hour_ends_on" with "2021-03-01"
+    And I fill in "office_hour_zoom_info" with "https://roblox.com"
+    And I check "recurrences_monday"
+    And I check "recurrences_tuesday"
+    And I fill in "office_hour_repeats_until" with "2021-03-09"
+    And I press "Save Changes"
+    Then I should be on the home page
+    And I should see "Underwater Basketweaving"
+    And I should see "TA-kun"
+    And I should see "03/01/2021"
+    And I should see "03/02/2021"
+    And I should see "03/08/2021"
+    And I should see "03/09/2021"

--- a/features/create_oh.feature
+++ b/features/create_oh.feature
@@ -19,7 +19,8 @@ Scenario: create an office hours
   Then I should be on the OH create page
   When I fill in "office_hour_host" with "TA-kun"
   And I fill in "office_hour_class_name" with "Underwater Basketweaving"
-  And I fill in "office_hour_time" with "4:20PM"
+  And I fill in "office_hour_starts_on" with "4:20PM"
+  And I fill in "office_hour_ends_on" with "5:20PM"
   And I fill in "office_hour_zoom_info" with "https://roblox.com"
   And I press "Save Changes"
   Then I should be on the home page

--- a/features/delete_oh.feature
+++ b/features/delete_oh.feature
@@ -4,32 +4,32 @@ Feature: Create a office hours session
   So that I may easily and orderly host office hours for my beloved students
   I want to delete an old and outdated OH
 
-Background: user and oh exists
+  Background: user and oh exists
     Given the following user exists:
-      | id | email               | password  |
-      | 1  | ta6969@colombia.edu | memexD |
+      | id | email               | password |
+      | 1  | ta6969@colombia.edu | memexD   |
 
     Given the following office hour exists:
-      | id | host   | class_name               | time   | zoom_info    | user_id |
-      | 1  | TA-kun | Underwater Basketwelding | 5:00PM | http://zo.om | 1       |
+      | id | host   | class_name               | starts_on | ends_on | zoom_info    | user_id |
+      | 1  | TA-kun | Underwater Basketwelding | 5:00PM    | 6:00PM  | http://zo.om | 1       |
 
-Scenario: delete an office hours
-  When I go to the home page
-  Then I go to the log in page
-  When I fill in "Email" with "ta6969@colombia.edu"
-  When I fill in "Password" with "memexD"
-  And I press "Log in"
+  Scenario: delete an office hours
+    When I go to the home page
+    Then I go to the log in page
+    When I fill in "Email" with "ta6969@colombia.edu"
+    When I fill in "Password" with "memexD"
+    And I press "Log in"
 
-  Then I should be on the home page
-  Then I follow "See more"
-  Then I should be on the office hour 1 page
-  When I follow "Delete"
-  Then I should be on the home page
-  And I should see "TA-kun's Underwater Basketwelding OH was successfully deleted."
-  And I should not see "See more"
+    Then I should be on the home page
+    Then I follow "See more"
+    Then I should be on the office hour 1 page
+    When I follow "Delete"
+    Then I should be on the home page
+    And I should see "TA-kun's Underwater Basketwelding OH was successfully deleted."
+    And I should not see "See more"
 
-Scenario: delete an office hour while not logged in
-  When I go to the home page
-  Then I follow "See more"
-  Then I should be on the office hour 1 page
-  And I should not see "Delete"
+  Scenario: delete an office hour while not logged in
+    When I go to the home page
+    Then I follow "See more"
+    Then I should be on the office hour 1 page
+    And I should not see "Delete"

--- a/features/queue.feature
+++ b/features/queue.feature
@@ -5,16 +5,16 @@ Feature: Join an office hours session
 
   Background: office hour exists
     Given the following user exists:
-      | id | email               | password    |
-      | 1  | ta6969@columbia.edu | memexD |
+      | id | email               | password |
+      | 1  | ta6969@columbia.edu | memexD   |
 
     Given the following office hour exists:
-      | id | host   | class_name               | time   | zoom_info    | user_id |
-      | 1  | TA-kun | Underwater Basketwelding | 5:00PM | http://zo.om | 1       |
+      | id | host   | class_name               | starts_on | ends_on | zoom_info    | user_id |
+      | 1  | TA-kun | Underwater Basketwelding | 5:00PM    | 6:00PM  | http://zo.om | 1       |
 
     Given the following queue entry exists:
-      | id   | student     | description  | creator_id | office_hour_id |
-      | 100  | Evan-senpai | amogusamogus | 12345      | 1              |
+      | id  | student     | description  | creator_id | office_hour_id |
+      | 100 | Evan-senpai | amogusamogus | 12345      | 1              |
 
   Scenario: Office hour hasn't started yet
     Given it is currently "4:00 pm"
@@ -37,7 +37,7 @@ Feature: Join an office hours session
     Then I should see "LET ME IN"
 
   @javascript
-    Scenario: User joins the queue and later removes themselves
+  Scenario: User joins the queue and later removes themselves
     Given it is currently "5:05 pm"
     And office hour 1 is active
     When I go to the home page
@@ -51,7 +51,7 @@ Feature: Join an office hours session
     Then I should not see "Curious Monky"
 
   @javascript
-    Scenario: User cannot delete queue entries of other users
+  Scenario: User cannot delete queue entries of other users
     Given it is currently "5:05 pm"
     And office hour 1 is active
     When I go to the home page

--- a/features/search_oh.feature
+++ b/features/search_oh.feature
@@ -4,46 +4,46 @@ Feature: display list of office hours filtered by search term
   So that I can quickly browse office hours that I need to attend
   I want to be able to search for specific OH and/or TAs
 
-Background: office hours have been added to database
-  Given the following users exist:
-  | id | email               | password    |
-  | 1  | ta6969@columbia.edu | memexD |
-  | 2  | senpai<3@columbia.edu | uwuOwO |
-  | 3  | monke@banana.edu | stinky |
-  | 4  | us@homeboys.edu | robloxmemexD |
+  Background: office hours have been added to database
+    Given the following users exist:
+      | id | email                 | password     |
+      | 1  | ta6969@columbia.edu   | memexD       |
+      | 2  | senpai<3@columbia.edu | uwuOwO       |
+      | 3  | monke@banana.edu      | stinky       |
+      | 4  | us@homeboys.edu       | robloxmemexD |
 
-  Given the following office hours exist:
-  | id | host   | class_name               | time   | zoom_info    | user_id |
-  | 1  | TA-kun | Underwater Basketwelding | 5:00PM | http://zo.om | 1       |
-  | 2  | Senpai | Advanced Anime Studies | 4:20PM | http://zo.om | 2       |
-  | 3  | Monke | Life in the Jungle | 5:40PM | http://zo.om | 3       |
-  | 4  | Us | Beginning Software Engineering | 3:00PM | http://zo.om | 4       |
+    Given the following office hours exist:
+      | id | host   | class_name                     | starts_on | ends_on | zoom_info    | user_id |
+      | 1  | TA-kun | Underwater Basketwelding       | 5:00PM    | 6:00PM  | http://zo.om | 1       |
+      | 2  | Senpai | Advanced Anime Studies         | 4:20PM    | 6:00PM  | http://zo.om | 2       |
+      | 3  | Monke  | Life in the Jungle             | 5:40PM    | 6:40PM  | http://zo.om | 3       |
+      | 4  | Us     | Beginning Software Engineering | 3:00PM    | 4:00PM  | http://zo.om | 4       |
 
-  And I am on the Q++ home page
-  Then 4 seed office hours should exist
+    And I am on the Q++ home page
+    Then 4 seed office hours should exist
 
-Scenario: search for host
-  Given I fill in "search_search" with "Monke"
-  And press "Search"
-  Then I should see "Monke"
-  And I should not see "Senpai"
-  And I should not see "TA-kun"
-  And I should not see "Us"
+  Scenario: search for host
+    Given I fill in "search_search" with "Monke"
+    And press "Search"
+    Then I should see "Monke"
+    And I should not see "Senpai"
+    And I should not see "TA-kun"
+    And I should not see "Us"
 
-Scenario: search for class
-  Given I fill in "search_search" with "Life"
-  And press "Search"
-  Then I should see "Monke"
-  And I should not see "Senpai"
-  And I should not see "TA-kun"
-  And I should not see "Us"
+  Scenario: search for class
+    Given I fill in "search_search" with "Life"
+    And press "Search"
+    Then I should see "Monke"
+    And I should not see "Senpai"
+    And I should not see "TA-kun"
+    And I should not see "Us"
 
-Scenario: clear filters
-  Given I fill in "search_search" with "Life"
-  And press "Search"
-  Then I should see "Monke"
-  And I should not see "Senpai"
-  And I should not see "TA-kun"
-  And I should not see "Us"
-  And I follow "Clear search"
-  Then I should see all office hours
+  Scenario: clear filters
+    Given I fill in "search_search" with "Life"
+    And press "Search"
+    Then I should see "Monke"
+    And I should not see "Senpai"
+    And I should not see "TA-kun"
+    And I should not see "Us"
+    And I follow "Clear search"
+    Then I should see all office hours

--- a/features/sort_oh.feature
+++ b/features/sort_oh.feature
@@ -4,38 +4,38 @@ Feature: display list of office hours sorted by different criteria
   So that I can quickly browse office hours based on my preferences
   I want to see offices sorted by host, class name, or time
 
-Background: movies have been added to database
-  Given the following users exist:
-  | id | email               | password    |
-  | 1  | ta6969@columbia.edu | memexD |
-  | 2  | senpai<3@columbia.edu | uwuOwO |
-  | 3  | monke@banana.edu | stinky |
-  | 4  | us@homeboys.edu | robloxmemexD |
+  Background: movies have been added to database
+    Given the following users exist:
+      | id | email                 | password     |
+      | 1  | ta6969@columbia.edu   | memexD       |
+      | 2  | senpai<3@columbia.edu | uwuOwO       |
+      | 3  | monke@banana.edu      | stinky       |
+      | 4  | us@homeboys.edu       | robloxmemexD |
 
-  Given the following office hour exists:
-  | id | host   | class_name               | time   | zoom_info    | user_id |
-  | 1  | TA-kun | Underwater Basketwelding | 5:00PM | http://zo.om | 1       |
-  | 2  | Senpai | Advanced Anime Studies | 4:20PM | http://zo.om | 2       |
-  | 3  | Monke | Life in the Jungle | 5:40PM | http://zo.om | 3       |
-  | 4  | Us | Beginning Software Engineering | 3:00PM | http://zo.om | 4       |
+    Given the following office hour exists:
+      | id | host   | class_name                     | starts_on | ends_on | zoom_info    | user_id |
+      | 1  | TA-kun | Underwater Basketwelding       | 5:00PM    | 6:00PM  | http://zo.om | 1       |
+      | 2  | Senpai | Advanced Anime Studies         | 4:20PM    | 5:20PM  | http://zo.om | 2       |
+      | 3  | Monke  | Life in the Jungle             | 5:40PM    | 6:40PM  | http://zo.om | 3       |
+      | 4  | Us     | Beginning Software Engineering | 3:00PM    | 4:00PM  | http://zo.om | 4       |
 
-  And I am on the Q++ home page
-  Then 4 seed office hours should exist
+    And I am on the Q++ home page
+    Then 4 seed office hours should exist
 
-Scenario: sort office hours by host
-  When I follow "Host"
-  Then I should see "Monke" before "Senpai"
-  Then I should see "Senpai" before "TA-kun"
-  Then I should see "TA-kun" before "Us"
+  Scenario: sort office hours by host
+    When I follow "Host"
+    Then I should see "Monke" before "Senpai"
+    Then I should see "Senpai" before "TA-kun"
+    Then I should see "TA-kun" before "Us"
 
-Scenario: sort office hours by class name
-  When I follow "Class Name"
-  Then I should see "Senpai" before "Us"
-  Then I should see "Us" before "Monke"
-  Then I should see "Monke" before "TA-kun"
+  Scenario: sort office hours by class name
+    When I follow "Class Name"
+    Then I should see "Senpai" before "Us"
+    Then I should see "Us" before "Monke"
+    Then I should see "Monke" before "TA-kun"
 
-Scenario: sort office hours by time
-  When I follow "When"
-  Then I should see "Us" before "Senpai"
-  Then I should see "Senpai" before "TA-kun"
-  Then I should see "TA-kun" before "Monke"
+  Scenario: sort office hours by time
+    When I follow "When"
+    Then I should see "Us" before "Senpai"
+    Then I should see "Senpai" before "TA-kun"
+    Then I should see "TA-kun" before "Monke"

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe OfficeHoursController, :type => :controller do
     it 'renders the show page' do
       test_user = User.new(email: "hans@mail", name: "Hans", surname: "Montero")
       test_user.save!(validate: false)
-      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", time: "2021-03-14 9:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
+      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", starts_on: "2021-03-14 9:40 PM", ends_on: "2021-03-14 11:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
       get :show, params: { id: test_oh.id }
       expect(response).to render_template("office_hours/show")
     end
@@ -42,7 +42,7 @@ RSpec.describe OfficeHoursController, :type => :controller do
       test_user = User.new(email: "hans@mail", name: "Hans", surname: "Montero")
       test_user.save!(validate: false)
       allow(controller).to receive(:current_user).and_return(test_user) 
-      post :create, params: {"office_hour": {host: "Hans", class_name: "OS", time: "2021-03-14 10:50 PM", zoom_info: "zoooom"}}
+      post :create, params: {"office_hour": {host: "Hans", class_name: "OS", starts_on: "2021-03-14 10:50 PM", ends_on: "2021-03-14 11:40 PM", zoom_info: "zoooom"}}
       expect(response).to redirect_to(:action => :index)
       expect(OfficeHour.where(class_name: "OS").length).to eq 1
     end
@@ -51,7 +51,7 @@ RSpec.describe OfficeHoursController, :type => :controller do
       test_user = User.new(email: "hans@mail", name: "Hans", surname: "Montero")
       test_user.save!(validate: false)
       allow(controller).to receive(:current_user).and_return(test_user) 
-      post :create, params: {"office_hour": {host: " ", class_name: "OS", time: "yyyy-mm-dd 10:50 PM", zoom_info: "zoooom"}}
+      post :create, params: {"office_hour": {host: " ", class_name: "OS", starts_on: "yyyy-mm-dd 10:50 PM", ends_on: "2021-03-14 11:40 PM", zoom_info: "zoooom"}}
       expect(response).to render_template("office_hours/new")
       expect(OfficeHour.all.length).to eq 0
       expect(flash[:notice]).to match(/Host can't be blank/)
@@ -60,7 +60,7 @@ RSpec.describe OfficeHoursController, :type => :controller do
     it 'deletes an OH, correct user' do
       test_user = User.new(email: "hans@mail", name: "Hans", surname: "Montero")
       test_user.save!(validate: false)
-      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", time: "2021-03-14 9:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
+      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", starts_on: "2021-03-14 9:40 PM", ends_on: "2021-03-14 11:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
       allow(controller).to receive(:current_user).and_return(test_user) 
       post :destroy, params: { id: test_oh.id }
       expect(response).to redirect_to(:action => :index)
@@ -72,7 +72,7 @@ RSpec.describe OfficeHoursController, :type => :controller do
       test_user.save!(validate: false)
       test_user2 = User.new(email: "hans2@mail", name: "Hans2", surname: "Montero2")
       test_user2.save!(validate: false)
-      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", time: "2021-03-14 9:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
+      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", starts_on: "2021-03-14 9:40 PM", ends_on: "2021-03-14 11:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
       allow(controller).to receive(:current_user).and_return(test_user2) 
       post :destroy, params: { id: test_oh.id }
       expect(response).to redirect_to(:action => :index)
@@ -84,7 +84,7 @@ RSpec.describe OfficeHoursController, :type => :controller do
   it 'renders the edit page, correct user' do
       test_user = User.new(email: "hans@mail", name: "Hans", surname: "Montero")
       test_user.save!(validate: false)
-      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", time: "2021-03-14 9:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
+      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", starts_on: "2021-03-14 9:40 PM", ends_on: "2021-03-14 11:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
 
       allow(controller).to receive(:current_user).and_return(test_user) 
       get :edit, params: { id: test_oh.id }
@@ -96,7 +96,7 @@ RSpec.describe OfficeHoursController, :type => :controller do
       test_user.save!(validate: false)
       test_user2 = User.new(email: "hans2@mail", name: "Hans2", surname: "Montero2")
       test_user2.save!(validate: false)
-      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", time: "2021-03-14 9:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
+      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", starts_on: "2021-03-14 9:40 PM", ends_on: "2021-03-14 11:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
 
       allow(controller).to receive(:current_user).and_return(test_user2) 
       get :edit, params: { id: test_oh.id }
@@ -107,10 +107,10 @@ RSpec.describe OfficeHoursController, :type => :controller do
   it 'updates the OH, correct user' do
       test_user = User.new(email: "hans@mail", name: "Hans", surname: "Montero")
       test_user.save!(validate: false)
-      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", time: "2021-03-14 9:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
+      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", starts_on: "2021-03-14 9:40 PM", ends_on: "2021-03-14 11:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
 
       allow(controller).to receive(:current_user).and_return(test_user) 
-      post :update, params: { id: test_oh.id, "office_hour": {host: "Hans", class_name: "OS", time: "2021-03-14 9:40 PM", zoom_info: "zoooom"} }
+      post :update, params: { id: test_oh.id, "office_hour": {host: "Hans", class_name: "OS", starts_on: "2021-03-14 9:40 PM", ends_on: "2021-03-14 11:40 PM", zoom_info: "zoooom"} }
       expect(response).to redirect_to(:action => :show, :id => test_oh.id)
       expect(OfficeHour.find(test_oh.id).class_name).to eq "OS"
   end
@@ -120,10 +120,10 @@ RSpec.describe OfficeHoursController, :type => :controller do
       test_user.save!(validate: false)
       test_user2 = User.new(email: "hans2@mail", name: "Hans2", surname: "Montero2")
       test_user2.save!(validate: false)
-      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", time: "2021-03-14 9:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
+      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", starts_on: "2021-03-14 9:40 PM", ends_on: "2021-03-14 11:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
 
       allow(controller).to receive(:current_user).and_return(test_user2) 
-      post :update, params: { id: test_oh.id, "office_hour": {host: "Hans", class_name: "OS", time: "2021-03-14 9:40 PM", zoom_info: "zoooom"} }
+      post :update, params: { id: test_oh.id, "office_hour": {host: "Hans", class_name: "OS", starts_on: "2021-03-14 9:40 PM", ends_on: "2021-03-14 11:40 PM", zoom_info: "zoooom"} }
       expect(flash[:notice]).to match(/You cannot edit this OH since you did not create it./)
       expect(response).to redirect_to(:action => :index)
       expect(OfficeHour.find(test_oh.id).class_name).to eq "PLT"
@@ -132,7 +132,7 @@ RSpec.describe OfficeHoursController, :type => :controller do
   it 'activates an OH' do
       test_user = User.new(email: "hans@mail", name: "Hans", surname: "Montero")
       test_user.save!(validate: false)
-      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", time: "2021-03-14 9:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
+      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", starts_on: "2021-03-14 9:40 PM", ends_on: "2021-03-14 11:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
 
       expect(test_oh.active).to eq false
       allow(controller).to receive(:current_user).and_return(test_user) 
@@ -144,7 +144,7 @@ RSpec.describe OfficeHoursController, :type => :controller do
   it 'deactivates an OH' do
       test_user = User.new(email: "hans@mail", name: "Hans", surname: "Montero")
       test_user.save!(validate: false)
-      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", time: "2021-03-14 9:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
+      test_oh = OfficeHour.create!(host: "Hans", class_name: "PLT", starts_on: "2021-03-14 9:40 PM", ends_on: "2021-03-14 9:40 PM", zoom_info: "zoooom", "user_id": test_user.id)
       QueueEntry.create!(student: "Matt", office_hour_id: test_oh.id)
 
       expect(test_oh.active).to eq false


### PR DESCRIPTION
This adds BASIC support assuming that any recurring meetings recur weekly on the days specified. The DB schema changes I made are flexible enough to support custom intervals and different repeat periods later if we want to extend.