### PR TITLE
Users press "join" instead of auto-joining Zoom call

### DIFF
--- a/app/controllers/zoom_controller.rb
+++ b/app/controllers/zoom_controller.rb
@@ -54,4 +54,9 @@ class ZoomController < ApplicationController
     @siggy = Zoom::SignatureGenerator.new(@meeting_number).signature
     render layout: false
   end
+
+  def join
+    @oh_id = params[:id]
+    render layout: false
+  end
 end

--- a/app/views/office_hours/show.html.erb
+++ b/app/views/office_hours/show.html.erb
@@ -62,7 +62,7 @@
   <% if @oh.active %>
   <div id="zoomCol" class="col-6">
       <div class="embed-responsive embed-responsive-16by9">
-        <iframe class="embed-responsive-item" src= <%= url_for controller: 'zoom', action: 'show', params: {:id => @oh} %>></iframe>
+        <iframe class="embed-responsive-item" src= <%= url_for controller: 'zoom', action: 'join', params: {:id => @oh} %>></iframe>
       </div>
   </div>
   <% end %>

--- a/app/views/zoom/join.html.erb
+++ b/app/views/zoom/join.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html class="h-100">
+<head>
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
+</head>
+<body class="h-100">
+<div class="container h-100">
+  <div class="row h-100 justify-content-center align-items-center">
+    <%= form_with url: zoom_path, local: true, method: 'get' do |form| %>
+    <%#= form_with url: url_for(controller: 'zoom', action: 'show', params: {id: @oh_id}), local: true, method: 'get' do |form| %>
+      <%= form.hidden_field  :id, value: @oh_id %>
+      <%= form.submit 'Join Zoom', class: 'btn btn-primary btn-lg' %>
+    <% end %>
+  </div>
+</div>
+</body>
+</html>

--- a/app/views/zoom/show.html.erb
+++ b/app/views/zoom/show.html.erb
@@ -23,7 +23,7 @@
         meetingNumber: "<%= @meeting_number %>",
         userName: "<%= @username %>",
         passWord: "<%= @password %>",
-        leaveUrl: "<%= zoom_path :id => @oh_id %>",
+        leaveUrl: "<%= zoom_join_path :id => @oh_id %>",
         role: 0, // Attendee
         userEmail: "",
         lang: "en-US",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   mount ActionCable.server => '/cable'
   root :to => redirect('/office_hours')
   get 'zoom', to: 'zoom#show'
+  get 'zoom/join', to: 'zoom#join'
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 


### PR DESCRIPTION
It looks something like this:

![Screenshot from 2021-04-06 01-07-02](https://user-images.githubusercontent.com/26512665/113661636-79df9280-9674-11eb-8855-ed6f4829f571.png)

Basically users have to press join before they are connected to Zoom meeting. After disconnecting the Zoom app redirects them back to the join button page. Obviously this only makes sense if the Zoom meeting is rendered in an iframe.